### PR TITLE
Implements Template Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.classpath
 /.settings
 /target
+*.iml
+*.idea

--- a/README.textile
+++ b/README.textile
@@ -160,7 +160,7 @@ If merging fails, the factory will not start.
 h3. Force rebuild mappings (use with caution)
 
 For test purpose or for continuous integration, you could force the factory to clean the previous @type@ when starting the client.
-It will *remove all your datas* for that @type@. Just set  @forceReinit@ property to @true@.
+It will *remove all your datas* for that @type@. Just set  @forceMapping@ property to @true@.
 
 bc. <bean id="esClient"
     class="fr.pilato.spring.elasticsearch.ElasticsearchClientFactoryBean" >
@@ -169,5 +169,5 @@ bc. <bean id="esClient"
 			<value>twitter/tweet</value>
 		</list>
 	</property>
-	<property name="forceReinit" value="true" />
+	<property name="forceMapping" value="true" />
 </bean>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   	
 	<properties>
 		<spring.version>3.1.1.RELEASE</spring.version>
-		<elasticsearch.version>0.19.1</elasticsearch.version>
+		<elasticsearch.version>0.19.3-SNAPSHOT</elasticsearch.version>
 	</properties>
 
 	<developers>

--- a/src/test/java/fr/pilato/spring/elasticsearch/xml/ElasticsearchTemplateTest.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/xml/ElasticsearchTemplateTest.java
@@ -1,0 +1,34 @@
+package fr.pilato.spring.elasticsearch.xml;
+
+import org.elasticsearch.client.Client;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class ElasticsearchTemplateTest {
+
+	static protected ConfigurableApplicationContext ctx;
+
+	@BeforeClass
+	static public void setup() {
+		ctx = new ClassPathXmlApplicationContext(
+				"fr/pilato/spring/elasticsearch/xml/es-template-test-context.xml");
+	}
+
+	@AfterClass
+	static public void tearDown() {
+		if (ctx != null) {
+			ctx.close();
+		}
+	}
+
+	@Test
+	public void test_transport_client() {
+		Client client = ctx.getBean("esClient", Client.class);
+		Assert.assertNotNull("Client must not be null...", client);
+	}
+
+}

--- a/src/test/resources/es-context.xml
+++ b/src/test/resources/es-context.xml
@@ -26,7 +26,7 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 				<value>alltheworld:rss</value>
 			</list>
 		</property>
-        <property name="forceReinit" value="true" />
+        <property name="forceMapping" value="true" />
     </bean>
     
 </beans>

--- a/src/test/resources/es6/_template/twitter_template.json
+++ b/src/test/resources/es6/_template/twitter_template.json
@@ -1,0 +1,16 @@
+{
+    "template" : "twee*",
+    "settings" : {
+        "number_of_shards" : 1
+    },
+    "mappings" : {
+        "tweet" : {
+            "properties" : {
+                "message" : {
+                    "type" : "string",
+                    "store" : "yes"
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/fr/pilato/spring/elasticsearch/xml/es-mapping-failed-test-context.xml
+++ b/src/test/resources/fr/pilato/spring/elasticsearch/xml/es-mapping-failed-test-context.xml
@@ -20,7 +20,7 @@
 				<value>twitter/tweet</value>
 			</list>
 		</property>
-        <property name="forceReinit" value="false" />
+        <property name="forceMapping" value="false" />
     </bean>	
 
     <bean id="esClient2"

--- a/src/test/resources/fr/pilato/spring/elasticsearch/xml/es-mapping-test-context.xml
+++ b/src/test/resources/fr/pilato/spring/elasticsearch/xml/es-mapping-test-context.xml
@@ -20,7 +20,7 @@
 				<value>twitter/tweet</value>
 			</list>
 		</property>
-        <property name="forceReinit" value="false" />
+        <property name="forceMapping" value="false" />
     </bean>	
 
     <bean id="esClient2"

--- a/src/test/resources/fr/pilato/spring/elasticsearch/xml/es-settings-failed-test-context.xml
+++ b/src/test/resources/fr/pilato/spring/elasticsearch/xml/es-settings-failed-test-context.xml
@@ -20,7 +20,7 @@
 				<value>twitter/tweet</value>
 			</list>
 		</property>
-        <property name="forceReinit" value="false" />
+        <property name="forceMapping" value="false" />
     </bean>	
 
     <bean id="esClient2"

--- a/src/test/resources/fr/pilato/spring/elasticsearch/xml/es-settings-test-context.xml
+++ b/src/test/resources/fr/pilato/spring/elasticsearch/xml/es-settings-test-context.xml
@@ -20,7 +20,7 @@
 				<value>twitter/tweet</value>
 			</list>
 		</property>
-        <property name="forceReinit" value="false" />
+        <property name="forceMapping" value="false" />
     </bean>	
 
     <bean id="esClient2"

--- a/src/test/resources/fr/pilato/spring/elasticsearch/xml/es-template-test-context.xml
+++ b/src/test/resources/fr/pilato/spring/elasticsearch/xml/es-template-test-context.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xmlns:elasticsearch="http://www.pilato.fr/schema/elasticsearch"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+		http://www.pilato.fr/schema/elasticsearch http://www.pilato.fr/schema/elasticsearch/elasticsearch-0.1.xsd">
+
+	<elasticsearch:node id="esNode"
+		settingsFile="fr/pilato/spring/elasticsearch/xml/esnode-transport.properties" />
+
+	<bean id="esClient"
+		class="fr.pilato.spring.elasticsearch.ElasticsearchClientFactoryBean">
+		<property name="node" ref="esNode" />
+		<property name="classpathRoot" value="/es6" />
+		<property name="templates">
+			<list>
+				<value>twitter_template</value>
+			</list>
+		</property>
+		<property name="forceTemplate" value="true" />
+	</bean>
+
+</beans>


### PR DESCRIPTION
Hi David,

I'd like to submit a pull request regarding the Index Template.
## Context

Elasticsearch support [index templating](http://www.elasticsearch.org/guide/reference/api/admin-indices-templates.html).

So IMO spring-elasticsearch should support this feature in the same way as mapping.
# Solution

In `ElasticsearchAbstractClientFactoryBean` class we have to add template support, so templates configuration will be scan in `es/_template` folder during Bean initialization.

To achieve this feature I had to submit a [pull request](https://github.com/elasticsearch/elasticsearch/issues/1861) to Shay (integrated yesterday)
## Changelog
- Upgrade elasticsearch version to 0.19-3-SNAPSHOT to use this [feature](https://github.com/elasticsearch/elasticsearch/issues/1860)
- Rename forceReinit to forceMapping in ElasticsearchAbstractClientFactoryBean
- Add Test ElasticsearchTemplateTest.java
