### PR TITLE
Adding tool namespace to better support IDEs

### DIFF
--- a/src/main/resources/fr/pilato/spring/elasticsearch/xml/elasticsearch-0.1.xsd
+++ b/src/main/resources/fr/pilato/spring/elasticsearch/xml/elasticsearch-0.1.xsd
@@ -11,14 +11,22 @@
 	governing permissions and limitations under the License. -->
 
 <xsd:schema xmlns="http://www.pilato.fr/schema/elasticsearch"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.pilato.fr/schema/elasticsearch"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tool="http://www.springframework.org/schema/tool"
+    targetNamespace="http://www.pilato.fr/schema/elasticsearch"
 	elementFormDefault="qualified">
+
+    <xsd:import namespace="http://www.springframework.org/schema/tool" schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
 
 	<xsd:element name="node">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[
 			Configures a org.elasticsearch.node.Node in the application context.
 		]]></xsd:documentation>
+            <xsd:appinfo>
+                <tool:annotation>
+                    <tool:exports type="org.elasticsearch.node.Node"/>
+                </tool:annotation>
+            </xsd:appinfo>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:attribute name="id" type="xsd:string">
@@ -52,6 +60,11 @@
 			<xsd:documentation><![CDATA[
 			Configures a org.elasticsearch.client.Client in the application context.
 		]]></xsd:documentation>
+            <xsd:appinfo>
+                <tool:annotation>
+                    <tool:exports type="org.elasticsearch.client.Client"/>
+                </tool:annotation>
+            </xsd:appinfo>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:attribute name="id" type="xsd:string">

--- a/src/main/resources/fr/pilato/spring/elasticsearch/xml/elasticsearch-0.2.xsd
+++ b/src/main/resources/fr/pilato/spring/elasticsearch/xml/elasticsearch-0.2.xsd
@@ -11,14 +11,22 @@
 	governing permissions and limitations under the License. -->
 
 <xsd:schema xmlns="http://www.pilato.fr/schema/elasticsearch"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.pilato.fr/schema/elasticsearch"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tool="http://www.springframework.org/schema/tool"
+    targetNamespace="http://www.pilato.fr/schema/elasticsearch"
 	elementFormDefault="qualified">
+
+    <xsd:import namespace="http://www.springframework.org/schema/tool" schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
 
 	<xsd:element name="node">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[
 			Configures a org.elasticsearch.node.Node in the application context.
 		]]></xsd:documentation>
+            <xsd:appinfo>
+                <tool:annotation>
+                    <tool:exports type="org.elasticsearch.node.Node"/>
+                </tool:annotation>
+            </xsd:appinfo>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:attribute name="id" type="xsd:string">
@@ -46,6 +54,11 @@
 
                         <elasticsearch:node id="esNode" properties="esProperties"  />
 				]]></xsd:documentation>
+                    <xsd:appinfo>
+                        <tool:annotation kind="ref">
+                            <tool:expected-type type="java.util.Properties"/>
+                        </tool:annotation>
+                    </xsd:appinfo>
                 </xsd:annotation>
             </xsd:attribute>
 			<xsd:attribute name="settingsFile" type="xsd:string">
@@ -66,6 +79,11 @@
 			<xsd:documentation><![CDATA[
 			Configures a org.elasticsearch.client.Client in the application context.
 		]]></xsd:documentation>
+            <xsd:appinfo>
+                <tool:annotation>
+                    <tool:exports type="org.elasticsearch.client.Client"/>
+                </tool:annotation>
+            </xsd:appinfo>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:attribute name="id" type="xsd:string">
@@ -113,6 +131,11 @@
 
                         <elasticsearch:node id="esNode" properties="esProperties"  />
 				]]></xsd:documentation>
+                    <xsd:appinfo>
+                        <tool:annotation kind="ref">
+                            <tool:expected-type type="java.util.Properties"/>
+                        </tool:annotation>
+                    </xsd:appinfo>
                 </xsd:annotation>
             </xsd:attribute>
 			<xsd:attribute name="settingsFile" type="xsd:string">

--- a/src/main/resources/fr/pilato/spring/elasticsearch/xml/elasticsearch-0.3.xsd
+++ b/src/main/resources/fr/pilato/spring/elasticsearch/xml/elasticsearch-0.3.xsd
@@ -11,14 +11,22 @@
 	governing permissions and limitations under the License. -->
 
 <xsd:schema xmlns="http://www.pilato.fr/schema/elasticsearch"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.pilato.fr/schema/elasticsearch"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tool="http://www.springframework.org/schema/tool"
+    targetNamespace="http://www.pilato.fr/schema/elasticsearch"
 	elementFormDefault="qualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/tool" schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
 
 	<xsd:element name="node">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[
 			Configures a org.elasticsearch.node.Node in the application context.
 		]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="org.elasticsearch.node.Node"/>
+				</tool:annotation>
+			</xsd:appinfo>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:attribute name="id" type="xsd:string">
@@ -46,8 +54,13 @@
 
                         <elasticsearch:node id="esNode" properties="esProperties"  />
 				]]></xsd:documentation>
-                </xsd:annotation>
-            </xsd:attribute>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="java.util.Properties"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
 			<xsd:attribute name="settingsFile" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
@@ -68,6 +81,11 @@
 			<xsd:documentation><![CDATA[
 			Configures a org.elasticsearch.client.Client in the application context.
 		]]></xsd:documentation>
+            <xsd:appinfo>
+                <tool:annotation>
+                    <tool:exports type="org.elasticsearch.client.Client"/>
+                </tool:annotation>
+            </xsd:appinfo>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:attribute name="id" type="xsd:string">
@@ -92,6 +110,11 @@
 					You must set this property to build a client from a node or
 					you must set esNodes property to build a transport client.
 				]]></xsd:documentation>
+                    <xsd:appinfo>
+                        <tool:annotation kind="ref">
+                            <tool:expected-type type="org.elasticsearch.node.Node"/>
+                        </tool:annotation>
+                    </xsd:appinfo>
 				</xsd:annotation>
 			</xsd:attribute>
 			<xsd:attribute name="esNodes" type="xsd:string">
@@ -115,8 +138,13 @@
 
                         <elasticsearch:node id="esNode" properties="esProperties"  />
 				]]></xsd:documentation>
-                </xsd:annotation>
-            </xsd:attribute>
+                    <xsd:appinfo>
+                        <tool:annotation kind="ref">
+                            <tool:expected-type type="java.util.Properties"/>
+                        </tool:annotation>
+                    </xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
 			<xsd:attribute name="settingsFile" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
@@ -220,7 +248,12 @@
 			<xsd:annotation> 
 				<xsd:documentation><![CDATA[
 				Task executor for asynchronously initialization
-				]]></xsd:documentation> 
+				]]></xsd:documentation>
+                <xsd:appinfo>
+                    <tool:annotation kind="ref">
+                        <tool:expected-type type="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor"/>
+                    </tool:annotation>
+                </xsd:appinfo>
 			</xsd:annotation>			
 		</xsd:attribute>
 	</xsd:attributeGroup>


### PR DESCRIPTION
Spring has a special tool namespace that allows developers of custom namespaces to annotate their XML schemas so IDEs like Spring Tool Suite and IntelliJ IDEA can provide code completion and error checking. I have added the tool namespace to the spring-elasticsearch schemas.
The tool namespace has the ability to define what Java types are exported from custom elements and what Java types are accepted in attributes. Here is an example:

``` xml
<xsd:element name="node">
    <xsd:annotation>
        <xsd:documentation><![CDATA[ ... ]]></xsd:documentation>
        <xsd:appinfo>
            <tool:annotation>
                <tool:exports type="org.elasticsearch.node.Node"/>
            </tool:annotation>
        </xsd:appinfo>
    </xsd:annotation>
    <!-- ... -->
</xsd:element>
```

Now when the custom namepsace is loaded in an IDE it will recognize the tool elements and provide errors and suggestions. No manual scanning will be required. Let me know if you have any questions.
