### PR TITLE
Add support for ingest pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ and automatically create index settings and templates based on what is found in 
 * `/es/_component_templates/` for [component templates](#component-templates)
 * `/es/_index_templates/` for [index templates](#index-templates)
 * `/es/_template/` for [legacy index templates](#templates-deprecated)
+* `/es/_pipeline/` for [ingest pipelines](#ingest-pipelines)
 
 ### Autoscan
 
@@ -306,7 +307,7 @@ Be careful: **IT WILL REMOVE ALL EXISTING DATA** FOR THE MANAGED INDICES.
 
 ### Component templates
 
-This feature will call the [Component Templates APIs](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html)
+This feature will call the [Component Templates APIs](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html).
 It's very common to use it with [index templates](#index-templates).
 
 Let say you want to create a component template named `component1`. Just create a file named
@@ -357,7 +358,7 @@ factory.setForceTemplate(false);
 
 ### Index templates
 
-This feature will call the [Index Templates APIs](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-templates.html)
+This feature will call the [Index Templates APIs](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-templates.html).
 It can be used with [component templates](#component-templates).
 
 Let say you want to create an index template named `template_1`. Just create a file named 
@@ -440,6 +441,40 @@ If you don't want to update the existing templates if any, you can set `forceTem
 ```java
 ElasticsearchRestClientFactoryBean factory = new ElasticsearchRestClientFactoryBean();
 factory.setForceTemplate(false);
+```
+
+### Ingest Pipelines
+
+This feature will call the [Ingest Pipelines APIs](https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html)
+
+Let say you want to create an ingest pipeline named `pipeline1`. Just create a file named
+`/es/_pipeline/pipeline1.json`:
+
+```json
+{
+  "description": "My optional pipeline description",
+  "processors": [
+    {
+      "set": {
+        "description": "My optional processor description",
+        "field": "my-long-field",
+        "value": 10
+      }
+    },
+    {
+      "set": {
+        "description": "Set 'my-boolean-field' to true",
+        "field": "my-boolean-field",
+        "value": true
+      }
+    },
+    {
+      "lowercase": {
+        "field": "my-keyword-field"
+      }
+    }
+  ]
+}
 ```
 
 ## Using XML (deprecated)
@@ -615,6 +650,15 @@ If you don't want to update the existing templates if any, you can set `forceTem
 <elasticsearch:rest-client id="esClient" forceTemplate="false" />
 ```
 
+### Creating ingest pipelines
+
+If you are not using autoscan, you can use the `pipelines` property to define the templates:
+
+```xml
+<elasticsearch:rest-client id="esClient"
+                           pipelines="pipeline1,pipeline2" />
+```
+
 ## Old fashion bean definition
 
 Note that you can use the old fashion method to define your beans instead of using `<elasticsearch:...>` namespace:
@@ -664,6 +708,11 @@ Note that you can use the old fashion method to define your beans instead of usi
         <property name="templates">
             <list>
                 <value>twitter_template</value>
+            </list>
+        </property>
+        <property name="pipelines">
+            <list>
+                <value>pipeline1</value>
             </list>
         </property>
         <property name="aliases">

--- a/src/main/java/fr/pilato/spring/elasticsearch/xml/ClientBeanDefinitionParser.java
+++ b/src/main/java/fr/pilato/spring/elasticsearch/xml/ClientBeanDefinitionParser.java
@@ -33,6 +33,7 @@ class ClientBeanDefinitionParser {
                                                     String aliases,
                                                     String componentTemplates, String indexTemplates,
                                                     String templates,
+                                                    String pipelines,
                                                     String async, String taskExecutor) {
         BeanDefinitionBuilder nodeFactory = BeanDefinitionBuilder.rootBeanDefinition(beanClass);
         if (properties != null && properties.length() > 0) {
@@ -59,6 +60,9 @@ class ClientBeanDefinitionParser {
         }
         if (templates != null && templates.length() > 0) {
             nodeFactory.addPropertyValue("templates", templates);
+        }
+        if (pipelines != null && pipelines.length() > 0) {
+            nodeFactory.addPropertyValue("pipelines", pipelines);
         }
 
 		if (async != null && async.length() > 0) {

--- a/src/main/java/fr/pilato/spring/elasticsearch/xml/RestClientBeanDefinitionParser.java
+++ b/src/main/java/fr/pilato/spring/elasticsearch/xml/RestClientBeanDefinitionParser.java
@@ -50,6 +50,7 @@ class RestClientBeanDefinitionParser implements BeanDefinitionParser {
         String componentTemplates = XMLParserUtil.getElementStringValue(element, "componentTemplates");
         String indexTemplates = XMLParserUtil.getElementStringValue(element, "indexTemplates");
         String templates = XMLParserUtil.getElementStringValue(element, "templates");
+        String pipelines = XMLParserUtil.getElementStringValue(element, "pipelines");
 
 		String taskExecutor = XMLParserUtil.getElementStringValue(element, "taskExecutor");
 
@@ -65,7 +66,9 @@ class RestClientBeanDefinitionParser implements BeanDefinitionParser {
         bdef.setBeanClass(ElasticsearchRestClientFactoryBean.class);
         BeanDefinitionBuilder clientBuilder = startClientBuilder(ElasticsearchRestClientFactoryBean.class,
                 properties, forceIndex, forceTemplate, mergeSettings, autoscan,
-                classpathRoot, mappings, aliases, componentTemplates, indexTemplates, templates, null, taskExecutor);
+                classpathRoot, mappings, aliases, componentTemplates, indexTemplates, templates,
+				pipelines,
+				null, taskExecutor);
         client = buildRestClientDef(clientBuilder, esNodes);
 
 		// Register NodeBeanDefinition

--- a/src/main/resources/elasticsearch-7.0.xsd
+++ b/src/main/resources/elasticsearch-7.0.xsd
@@ -158,7 +158,16 @@
 				]]></xsd:documentation>
                 </xsd:annotation>
             </xsd:attribute>
-
+            <xsd:attribute name="pipelines" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[
+					List of pipelines (comma separated)
+					if you are not using automatic discovery (see autoscan)
+                    Example:
+                        "pipeline1,pipeline2"
+				]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
         </xsd:complexType>
     </xsd:element>
 

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/pipelines/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/pipelines/AppConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.spring.elasticsearch.it.annotation.rest.pipelines;
+
+import fr.pilato.spring.elasticsearch.ElasticsearchRestClientFactoryBean;
+import fr.pilato.spring.elasticsearch.it.annotation.rest.RestAppConfig;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig extends RestAppConfig {
+
+	@Override
+	protected void enrichFactory(ElasticsearchRestClientFactoryBean factory) {
+		factory.setClasspathRoot("/models/root/pipelines");
+	}
+
+}

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/pipelines/PipelinesTest.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/pipelines/PipelinesTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.spring.elasticsearch.it.annotation.rest.pipelines;
+
+import fr.pilato.elasticsearch.tools.updaters.ElasticsearchPipelineUpdater;
+import fr.pilato.spring.elasticsearch.it.annotation.rest.AbstractRestAnnotationContextModel;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+
+public class PipelinesTest extends AbstractRestAnnotationContextModel {
+
+    @Override
+    protected void executeBefore(RestClient client) throws IOException {
+        try {
+            client.performRequest(new Request("DELETE", "/_pipeline/pipeline1"));
+        } catch (ResponseException ignored) { }
+    }
+
+    @Override
+    protected String indexName() {
+        return null;
+    }
+
+    protected void checkUseCaseSpecific(RestHighLevelClient client) throws IOException {
+        assertThat(ElasticsearchPipelineUpdater.isPipelineExist(client.getLowLevelClient(), "pipeline1"), is(true));
+    }
+}

--- a/src/test/resources/models/root/pipelines/_pipeline/pipeline1.json
+++ b/src/test/resources/models/root/pipelines/_pipeline/pipeline1.json
@@ -1,0 +1,24 @@
+{
+  "description": "My optional pipeline description",
+  "processors": [
+    {
+      "set": {
+        "description": "My optional processor description",
+        "field": "my-long-field",
+        "value": 10
+      }
+    },
+    {
+      "set": {
+        "description": "Set 'my-boolean-field' to true",
+        "field": "my-boolean-field",
+        "value": true
+      }
+    },
+    {
+      "lowercase": {
+        "field": "my-keyword-field"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This feature will call the [Ingest Pipelines APIs](https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html)

Let say you want to create an ingest pipeline named `pipeline1`. Just create a file named
`/es/_pipeline/pipeline1.json`:

```json
{
  "description": "My optional pipeline description",
  "processors": [
    {
      "set": {
        "description": "My optional processor description",
        "field": "my-long-field",
        "value": 10
      }
    },
    {
      "set": {
        "description": "Set 'my-boolean-field' to true",
        "field": "my-boolean-field",
        "value": true
      }
    },
    {
      "lowercase": {
        "field": "my-keyword-field"
      }
    }
  ]
}
```