### PR TITLE
Add support for `_aliases.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ and automatically create index settings and templates based on what is found in 
 * `/es/_index_templates/` for [index templates](#index-templates)
 * `/es/_templates/` for [legacy index templates](#templates-deprecated)
 * `/es/_pipelines/` for [ingest pipelines](#ingest-pipelines)
+* `/es/_aliases.json` for [aliases](#aliases)
 
 ## Documentation
 
@@ -243,6 +244,7 @@ and automatically create index settings and templates based on what is found in 
 * `/es/_index_templates/` for [index templates](#index-templates)
 * `/es/_templates/` for [legacy index templates](#templates-deprecated)
 * `/es/_pipelines/` for [ingest pipelines](#ingest-pipelines)
+* `/es/_aliases.json` for [aliases](#aliases)
 
 ### Autoscan
 
@@ -424,6 +426,23 @@ to define a template named `twitter_template`, you have to define a file named `
     }
 }
 ```
+
+### Aliases
+
+An alias is helpful to define or remove an alias to a given index. You could also use an [index templates](#index-templates)
+to do that automatically when at index creation time, but you can also define a file `/es/_aliases.json`:
+
+```json
+{
+  "actions" : [
+    { "remove": { "index": "test_1", "alias": "test" } },
+    { "add":  { "index": "test_2", "alias": "test" } }
+  ]
+}
+```
+
+When the factory starts, it will automatically send the content to the [Aliases API](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html)
+and move the alias `test` from index `test_1` to index `test_2`.
 
 ### Ingest Pipelines
 

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/aliases/AliasesTest.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/aliases/AliasesTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 
 public class AliasesTest extends AbstractRestAnnotationContextModel {
 
@@ -35,5 +36,9 @@ public class AliasesTest extends AbstractRestAnnotationContextModel {
         assertThat(response, hasKey("rss"));
         assertThat(response, hasKey("twitter"));
         assertShardsAndReplicas(client.getLowLevelClient(), "rss", 1, 1);
+
+        response = runRestQuery(client.getLowLevelClient(), "/_alias/test");
+        assertThat(response, not(hasKey("test_1")));
+        assertThat(response, hasKey("test_2"));
     }
 }

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/aliases/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/aliases/AppConfig.java
@@ -28,8 +28,8 @@ public class AppConfig extends RestAppConfig {
 
 	@Override
 	protected void enrichFactory(ElasticsearchRestClientFactoryBean factory) {
+		factory.setClasspathRoot("/models/root/aliases");
 		factory.setAliases(new String[]{"alltheworld:twitter", "alltheworld:rss"});
-		factory.setIndices(new String[]{"twitter", "rss"});
 		factory.setForceIndex(true);
 	}
 

--- a/src/test/resources/models/root/aliases/_aliases.json
+++ b/src/test/resources/models/root/aliases/_aliases.json
@@ -1,0 +1,6 @@
+{
+  "actions" : [
+    { "remove": { "index": "test_1", "alias": "test" } },
+    { "add":  { "index": "test_2", "alias": "test" } }
+  ]
+}

--- a/src/test/resources/models/root/aliases/test_1/_settings.json
+++ b/src/test/resources/models/root/aliases/test_1/_settings.json
@@ -1,0 +1,10 @@
+{
+  "mappings": {
+    "properties" : {
+      "message" : {"type" : "text", "store" : true}
+    }
+  },
+  "aliases": {
+    "test": { }
+  }
+}

--- a/src/test/resources/models/root/aliases/test_2/_settings.json
+++ b/src/test/resources/models/root/aliases/test_2/_settings.json
@@ -1,0 +1,7 @@
+{
+  "mappings": {
+    "properties" : {
+      "message" : {"type" : "text", "store" : true}
+    }
+  }
+}

--- a/src/test/resources/models/root/aliases/twitter/_settings.json
+++ b/src/test/resources/models/root/aliases/twitter/_settings.json
@@ -1,0 +1,7 @@
+{
+  "mappings": {
+    "properties" : {
+      "message" : {"type" : "text", "store" : true}
+    }
+  }
+}


### PR DESCRIPTION
An alias is helpful to define or remove an alias to a given index. You could also use an index templates
to do that automatically when at index creation time, but you can also define a file `/es/_aliases.json`:

```json
{
  "actions" : [
    { "remove": { "index": "test_1", "alias": "test" } },
    { "add":  { "index": "test_2", "alias": "test" } }
  ]
}
```

When the factory starts, it will automatically send the content to the [Aliases API](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html)
and move the alias `test` from index `test_1` to index `test_2`.

Closes #36.