### PR TITLE
Deprecate `setProperties(Properties)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ and automatically create index settings and templates based on what is found in 
 * Provides now the new official [Java Rest Client for Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/)
 * Removed deprecated templates
 * Removed deprecated XML support
+* Deprecated `setProperties(Properties)` method.
 
 ### Changes in 7.1
 

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/RestAppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/RestAppConfig.java
@@ -23,16 +23,13 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import fr.pilato.spring.elasticsearch.ElasticsearchClientFactoryBean;
 import org.springframework.context.annotation.Bean;
 
-import java.util.Properties;
-
 public abstract class RestAppConfig {
 
 	abstract protected void enrichFactory(ElasticsearchClientFactoryBean factory);
 
 	@Bean
-	public ElasticsearchClient esClient(Properties esProperties) throws Exception {
+	public ElasticsearchClient esClient() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setProperties(esProperties);
 		factory.setUsername("elastic");
 		factory.setPassword("changeme");
 		factory.setCheckSelfSignedCertificates(false);

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/indicesalreadyexist/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/indicesalreadyexist/AppConfig.java
@@ -25,8 +25,6 @@ import fr.pilato.spring.elasticsearch.it.annotation.rest.RestAppConfig;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.Properties;
-
 @Configuration
 public class AppConfig extends RestAppConfig {
 
@@ -36,9 +34,8 @@ public class AppConfig extends RestAppConfig {
 	}
 
 	@Bean
-	public ElasticsearchClient esClient2(Properties esProperties) throws Exception {
+	public ElasticsearchClient esClient2() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setProperties(esProperties);
 		factory.setUsername("elastic");
 		factory.setPassword("changeme");
 		factory.setCheckSelfSignedCertificates(false);

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/mapping/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/mapping/AppConfig.java
@@ -25,8 +25,6 @@ import fr.pilato.spring.elasticsearch.it.annotation.rest.RestAppConfig;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.Properties;
-
 @Configuration
 public class AppConfig extends RestAppConfig {
 
@@ -38,9 +36,8 @@ public class AppConfig extends RestAppConfig {
 	}
 
 	@Bean
-	public ElasticsearchClient esClient2(Properties esProperties) throws Exception {
+	public ElasticsearchClient esClient2() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setProperties(esProperties);
 		factory.setUsername("elastic");
 		factory.setPassword("changeme");
 		factory.setCheckSelfSignedCertificates(false);

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/mappingfailed/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/mappingfailed/AppConfig.java
@@ -24,15 +24,12 @@ import fr.pilato.spring.elasticsearch.ElasticsearchClientFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.Properties;
-
 @Configuration
 public class AppConfig {
 
 	@Bean
-	public ElasticsearchClient esClient(Properties esProperties) throws Exception {
+	public ElasticsearchClient esClient() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setProperties(esProperties);
 		factory.setUsername("elastic");
 		factory.setPassword("changeme");
 		factory.setCheckSelfSignedCertificates(false);
@@ -44,9 +41,8 @@ public class AppConfig {
 	}
 
 	@Bean
-	public ElasticsearchClient esClient2(Properties esProperties) throws Exception {
+	public ElasticsearchClient esClient2() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setProperties(esProperties);
 		factory.setUsername("elastic");
 		factory.setPassword("changeme");
 		factory.setCheckSelfSignedCertificates(false);

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/multipleclients/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/multipleclients/AppConfig.java
@@ -24,15 +24,12 @@ import fr.pilato.spring.elasticsearch.ElasticsearchClientFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.Properties;
-
 @Configuration
 public class AppConfig {
 
 	@Bean
-	public ElasticsearchClient esClient(Properties esProperties) throws Exception {
+	public ElasticsearchClient esClient() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setProperties(esProperties);
 		factory.setUsername("elastic");
 		factory.setPassword("changeme");
 		factory.setCheckSelfSignedCertificates(false);
@@ -44,9 +41,8 @@ public class AppConfig {
 	}
 
 	@Bean
-	public ElasticsearchClient esClient2(Properties esProperties) throws Exception {
+	public ElasticsearchClient esClient2() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setProperties(esProperties);
 		factory.setUsername("elastic");
 		factory.setPassword("changeme");
 		factory.setCheckSelfSignedCertificates(false);

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/settingsfailed/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/settingsfailed/AppConfig.java
@@ -24,15 +24,12 @@ import fr.pilato.spring.elasticsearch.ElasticsearchClientFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.Properties;
-
 @Configuration
 public class AppConfig {
 
 	@Bean
-	public ElasticsearchClient esClient(Properties esProperties) throws Exception {
+	public ElasticsearchClient esClient() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setProperties(esProperties);
 		factory.setUsername("elastic");
 		factory.setPassword("changeme");
 		factory.setCheckSelfSignedCertificates(false);
@@ -44,9 +41,8 @@ public class AppConfig {
 	}
 
 	@Bean
-	public ElasticsearchClient esClient2(Properties esProperties) throws Exception {
+	public ElasticsearchClient esClient2() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setProperties(esProperties);
 		factory.setUsername("elastic");
 		factory.setPassword("changeme");
 		factory.setCheckSelfSignedCertificates(false);

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/updatesettingsdisabled31/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/updatesettingsdisabled31/AppConfig.java
@@ -24,15 +24,12 @@ import fr.pilato.spring.elasticsearch.ElasticsearchClientFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.Properties;
-
 @Configuration
 public class AppConfig {
 
 	@Bean
-	public ElasticsearchClient esClient(Properties esProperties) throws Exception {
+	public ElasticsearchClient esClient() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setProperties(esProperties);
 		factory.setUsername("elastic");
 		factory.setPassword("changeme");
 		factory.setCheckSelfSignedCertificates(false);
@@ -42,9 +39,8 @@ public class AppConfig {
 	}
 
 	@Bean
-	public ElasticsearchClient esClient2(Properties esProperties) throws Exception {
+	public ElasticsearchClient esClient2() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setProperties(esProperties);
 		factory.setUsername("elastic");
 		factory.setPassword("changeme");
 		factory.setCheckSelfSignedCertificates(false);

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/updatesettingsenabled31/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/updatesettingsenabled31/AppConfig.java
@@ -24,15 +24,12 @@ import fr.pilato.spring.elasticsearch.ElasticsearchClientFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.Properties;
-
 @Configuration
 public class AppConfig {
 
 	@Bean
-	public ElasticsearchClient esClient(Properties esProperties) throws Exception {
+	public ElasticsearchClient esClient() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setProperties(esProperties);
 		factory.setUsername("elastic");
 		factory.setPassword("changeme");
 		factory.setCheckSelfSignedCertificates(false);
@@ -42,9 +39,8 @@ public class AppConfig {
 	}
 
 	@Bean
-	public ElasticsearchClient esClient2(Properties esProperties) throws Exception {
+	public ElasticsearchClient esClient2() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setProperties(esProperties);
 		factory.setUsername("elastic");
 		factory.setPassword("changeme");
 		factory.setCheckSelfSignedCertificates(false);


### PR DESCRIPTION
This was only used for setting Elastic username and password. We now have proper `setUsername(String)` and `setPassword(String)` methods.