### PR TITLE
Add support for setSslContext(SSLContext)

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,26 @@ If you want to apply this policy to your index, you can define the following set
 }
 ```
 
+### SSL certificates
+
+If you need to specify your own SSL certificates (self-signed certificates), you can use the `setSSLContext(SSLContext)`
+method to do this.
+You can refer to the Elasticsearch [Low Level client documentation](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/_encrypted_communication.html)
+to see some examples. Once you have created a SSLContext, you can use it in the factory:
+
+```java
+Path trustStorePath = Paths.get("/path/to/truststore.p12");
+KeyStore truststore = KeyStore.getInstance("pkcs12");
+try (InputStream is = Files.newInputStream(trustStorePath)) {
+    truststore.load(is, keyStorePass.toCharArray());
+}
+SSLContextBuilder sslBuilder = SSLContexts.custom().loadTrustMaterial(truststore, null);
+final SSLContext sslContext = sslBuilder.build();
+
+ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
+factory.setSslContext(sslContext);
+```
+
 # Thanks
 
 Special thanks to
@@ -527,12 +547,18 @@ Special thanks to
 # Running tests
 
 If you want to run tests (integration tests) from your IDE, you need to start first an elasticsearch instance.
-Tests are expecting a node running at `localhost:9200`.
+Tests are expecting a node running at `https://localhost:9200` with the user `elastic` and `changeme` as the password.
 
 To run the tests using Maven (on the CLI), just run:
 
 ```sh
 mvn clean install
+```
+
+You can change the target to run the tests. For example, if you want to run the tests against an elastic cloud instance:
+
+```shell
+mvn clean install -Dtests.cluster=https://ID.es.ZONE.PROVIDER.cloud.es.io -Dtests.cluster.user=myuser -Dtests.cluster.pass=YOURPASSWORD
 ```
 
 # Release guide

--- a/src/main/java/fr/pilato/spring/elasticsearch/SSLUtils.java
+++ b/src/main/java/fr/pilato/spring/elasticsearch/SSLUtils.java
@@ -19,20 +19,44 @@
 
 package fr.pilato.spring.elasticsearch;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
 public class SSLUtils {
+    private static final Logger logger = LoggerFactory.getLogger(SSLUtils.class);
     private static SSLContext yesCtx = null;
+    private static SSLContext checkCertificatesSSLContext = null;
 
     /**
      * Returns an SSLContext that will accept any server certificate.
      * Use with great care and in limited situations, as it allows MITM attacks.
      */
     public static SSLContext yesSSLContext() {
-        if (yesCtx == null) {
+        logger.warn("You disabled checking the https certificate. This could lead to " +
+                "'Man in the middle' attacks. This setting is only intended for tests.");
 
+        if (yesCtx == null) {
             X509TrustManager yesTm = new X509TrustManager() {
                 @Override
                 public void checkClientTrusted(X509Certificate[] certs, String authType) {
@@ -61,5 +85,51 @@ public class SSLUtils {
         }
 
         return yesCtx;
+    }
+
+    /**
+     *
+     * @param trustStore
+     * @param keyStoreType  pkcs12
+     * @return
+     */
+    public static SSLContext checkCertificatesSSLContext(String trustStore, String keyStoreType, String keyStorePass) {
+        if (checkCertificatesSSLContext == null) {
+            try {
+                Path trustStorePath = Paths.get(trustStore);
+                KeyStore truststore = KeyStore.getInstance(keyStoreType);
+                try (InputStream is = Files.newInputStream(trustStorePath)) {
+                    truststore.load(is, keyStorePass.toCharArray());
+                }
+                SSLContextBuilder sslBuilder = SSLContexts.custom().loadTrustMaterial(truststore, null);
+                checkCertificatesSSLContext = sslBuilder.build();
+            } catch (IOException | CertificateException | NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
+                logger.error("Can not load the SSLContext for {}, {}", trustStore, keyStoreType);
+            }
+        }
+        return checkCertificatesSSLContext;
+    }
+
+    /**
+     * A SSL context based on the self signed CA, so that using this SSL Context allows to connect to the Elasticsearch service
+     * @return a customized SSL Context
+     */
+    public SSLContext createSslContextFromCa(String certPath) {
+        try {
+            byte[] bytes = IOUtils.resourceToByteArray(certPath);
+            CertificateFactory factory = CertificateFactory.getInstance("X.509");
+            Certificate trustedCa = factory.generateCertificate(new ByteArrayInputStream(bytes));
+            KeyStore trustStore = KeyStore.getInstance("pkcs12");
+            trustStore.load(null, null);
+            trustStore.setCertificateEntry("ca", trustedCa);
+
+            final SSLContext sslContext = SSLContext.getInstance("TLSv1.3");
+            TrustManagerFactory tmfactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            tmfactory.init(trustStore);
+            sslContext.init(null, tmfactory.getTrustManagers(), null);
+            return sslContext;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/RestAppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/RestAppConfig.java
@@ -21,7 +21,13 @@ package fr.pilato.spring.elasticsearch.it.annotation.rest;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import fr.pilato.spring.elasticsearch.ElasticsearchClientFactoryBean;
+import fr.pilato.spring.elasticsearch.SSLUtils;
+import org.apache.http.HttpHost;
 import org.springframework.context.annotation.Bean;
+
+import java.util.List;
+
+import static fr.pilato.spring.elasticsearch.it.BaseTest.*;
 
 public abstract class RestAppConfig {
 
@@ -30,11 +36,18 @@ public abstract class RestAppConfig {
 	@Bean
 	public ElasticsearchClient esClient() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setUsername("elastic");
-		factory.setPassword("changeme");
-		factory.setCheckSelfSignedCertificates(false);
+		enrichFactoryWithNodeSettings(factory);
 		enrichFactory(factory);
 		factory.afterPropertiesSet();
 		return factory.getObject();
+	}
+
+	public static void enrichFactoryWithNodeSettings(ElasticsearchClientFactoryBean factory) {
+		factory.setEsNodes(List.of(HttpHost.create(testCluster)));
+		factory.setUsername(testClusterUser);
+		factory.setPassword(testClusterPass);
+		if (testCluster.equals(DEFAULT_TEST_CLUSTER)) {
+			factory.setSslContext(SSLUtils.yesSSLContext());
+		}
 	}
 }

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/indicesalreadyexist/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/indicesalreadyexist/AppConfig.java
@@ -36,9 +36,7 @@ public class AppConfig extends RestAppConfig {
 	@Bean
 	public ElasticsearchClient esClient2() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setUsername("elastic");
-		factory.setPassword("changeme");
-		factory.setCheckSelfSignedCertificates(false);
+		enrichFactoryWithNodeSettings(factory);
 		factory.setClasspathRoot("/models/root/indices-already-exist-86/client");
 		factory.afterPropertiesSet();
 		return factory.getObject();

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/mapping/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/mapping/AppConfig.java
@@ -37,9 +37,7 @@ public class AppConfig extends RestAppConfig {
 	@Bean
 	public ElasticsearchClient esClient2() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setUsername("elastic");
-		factory.setPassword("changeme");
-		factory.setCheckSelfSignedCertificates(false);
+		enrichFactoryWithNodeSettings(factory);
 		factory.setClasspathRoot("/models/root/mapping/client2");
 		factory.setMergeSettings(true);
 		factory.afterPropertiesSet();

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/mappingfailed/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/mappingfailed/AppConfig.java
@@ -24,15 +24,15 @@ import fr.pilato.spring.elasticsearch.ElasticsearchClientFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static fr.pilato.spring.elasticsearch.it.annotation.rest.RestAppConfig.enrichFactoryWithNodeSettings;
+
 @Configuration
 public class AppConfig {
 
 	@Bean
 	public ElasticsearchClient esClient() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setUsername("elastic");
-		factory.setPassword("changeme");
-		factory.setCheckSelfSignedCertificates(false);
+		enrichFactoryWithNodeSettings(factory);
 		factory.setClasspathRoot("/models/root/mapping-failed/client1");
 		factory.setForceIndex(false);
 		factory.afterPropertiesSet();
@@ -42,9 +42,7 @@ public class AppConfig {
 	@Bean
 	public ElasticsearchClient esClient2() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setUsername("elastic");
-		factory.setPassword("changeme");
-		factory.setCheckSelfSignedCertificates(false);
+		enrichFactoryWithNodeSettings(factory);
 		factory.setClasspathRoot("/models/root/mapping-failed/client2");
 		factory.setMergeSettings(true);
 		factory.afterPropertiesSet();

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/multipleclients/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/multipleclients/AppConfig.java
@@ -24,15 +24,15 @@ import fr.pilato.spring.elasticsearch.ElasticsearchClientFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static fr.pilato.spring.elasticsearch.it.annotation.rest.RestAppConfig.enrichFactoryWithNodeSettings;
+
 @Configuration
 public class AppConfig {
 
 	@Bean
 	public ElasticsearchClient esClient() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setUsername("elastic");
-		factory.setPassword("changeme");
-		factory.setCheckSelfSignedCertificates(false);
+		enrichFactoryWithNodeSettings(factory);
 		factory.setClasspathRoot("/models/root/multiple-clients/client1");
 		factory.setForceIndex(false);
 		factory.afterPropertiesSet();
@@ -42,9 +42,7 @@ public class AppConfig {
 	@Bean
 	public ElasticsearchClient esClient2() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setUsername("elastic");
-		factory.setPassword("changeme");
-		factory.setCheckSelfSignedCertificates(false);
+		enrichFactoryWithNodeSettings(factory);
 		factory.setClasspathRoot("/models/root/multiple-clients/client2");
 		factory.setMergeSettings(true);
 		factory.afterPropertiesSet();

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/settingsfailed/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/settingsfailed/AppConfig.java
@@ -24,15 +24,15 @@ import fr.pilato.spring.elasticsearch.ElasticsearchClientFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static fr.pilato.spring.elasticsearch.it.annotation.rest.RestAppConfig.enrichFactoryWithNodeSettings;
+
 @Configuration
 public class AppConfig {
 
 	@Bean
 	public ElasticsearchClient esClient() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setUsername("elastic");
-		factory.setPassword("changeme");
-		factory.setCheckSelfSignedCertificates(false);
+		enrichFactoryWithNodeSettings(factory);
 		factory.setClasspathRoot("/models/root/settings-failed/client1");
 		factory.setForceIndex(false);
 		factory.afterPropertiesSet();
@@ -42,9 +42,7 @@ public class AppConfig {
 	@Bean
 	public ElasticsearchClient esClient2() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setUsername("elastic");
-		factory.setPassword("changeme");
-		factory.setCheckSelfSignedCertificates(false);
+		enrichFactoryWithNodeSettings(factory);
 		factory.setClasspathRoot("/models/root/settings-failed/client2");
 		factory.setMergeSettings(true);
 		factory.afterPropertiesSet();

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/updatesettingsdisabled31/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/updatesettingsdisabled31/AppConfig.java
@@ -24,15 +24,15 @@ import fr.pilato.spring.elasticsearch.ElasticsearchClientFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static fr.pilato.spring.elasticsearch.it.annotation.rest.RestAppConfig.enrichFactoryWithNodeSettings;
+
 @Configuration
 public class AppConfig {
 
 	@Bean
 	public ElasticsearchClient esClient() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setUsername("elastic");
-		factory.setPassword("changeme");
-		factory.setCheckSelfSignedCertificates(false);
+		enrichFactoryWithNodeSettings(factory);
 		factory.setClasspathRoot("/models/root/update-settings-31/client1");
 		factory.afterPropertiesSet();
 		return factory.getObject();
@@ -41,9 +41,7 @@ public class AppConfig {
 	@Bean
 	public ElasticsearchClient esClient2() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setUsername("elastic");
-		factory.setPassword("changeme");
-		factory.setCheckSelfSignedCertificates(false);
+		enrichFactoryWithNodeSettings(factory);
 		factory.setClasspathRoot("/models/root/update-settings-31/client2");
 		factory.setMergeSettings(false);
 		factory.afterPropertiesSet();

--- a/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/updatesettingsenabled31/AppConfig.java
+++ b/src/test/java/fr/pilato/spring/elasticsearch/it/annotation/rest/updatesettingsenabled31/AppConfig.java
@@ -24,15 +24,15 @@ import fr.pilato.spring.elasticsearch.ElasticsearchClientFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static fr.pilato.spring.elasticsearch.it.annotation.rest.RestAppConfig.enrichFactoryWithNodeSettings;
+
 @Configuration
 public class AppConfig {
 
 	@Bean
 	public ElasticsearchClient esClient() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setUsername("elastic");
-		factory.setPassword("changeme");
-		factory.setCheckSelfSignedCertificates(false);
+		enrichFactoryWithNodeSettings(factory);
 		factory.setClasspathRoot("/models/root/update-settings-disabled-31/client1");
 		factory.afterPropertiesSet();
 		return factory.getObject();
@@ -41,9 +41,7 @@ public class AppConfig {
 	@Bean
 	public ElasticsearchClient esClient2() throws Exception {
 		ElasticsearchClientFactoryBean factory = new ElasticsearchClientFactoryBean();
-		factory.setUsername("elastic");
-		factory.setPassword("changeme");
-		factory.setCheckSelfSignedCertificates(false);
+		enrichFactoryWithNodeSettings(factory);
 		factory.setClasspathRoot("/models/root/update-settings-disabled-31/client2");
 		factory.setMergeSettings(true);
 		factory.afterPropertiesSet();


### PR DESCRIPTION
With that, you can pass your own SSLContext which is useful if you have to deal with self-signed certificates for example.